### PR TITLE
Fix Vue Router guard

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -77,21 +77,21 @@ Vue.use(VueRouter);
 export const router = new VueRouter({
   routes,
 });
-router.beforeEach((route, redirect, next) => {
-  if (route.matched.some(m => m.meta.auth) && !store.state.auth.authenticated) {
+router.beforeEach((toRoute, fromRoute, next) => {
+  if (toRoute.matched.some(m => m.meta.auth) && !store.state.auth.authenticated) {
     /*
      * If the user is not authenticated and visits
      * a page that requires authentication, redirect to the login page
      */
-    redirect({
+    next({
       name: 'login.index',
     });
-  } else if (route.matched.some(m => m.meta.guest) && store.state.auth.authenticated) {
+  } else if (toRoute.matched.some(m => m.meta.guest) && store.state.auth.authenticated) {
     /*
      * If the user is authenticated and visits
      * an guest page, redirect to the dashboard page
      */
-    redirect({
+    next({
       name: 'account.show',
     });
   } else {


### PR DESCRIPTION
#13 
Acoording to [Vue Router Documentation](http://router.vuejs.org/en/advanced/navigation-guards.html) global guards has the following signature:

router.beforeEach((to, from, next) => {
// ...
})

So to redirect we have to use the next argument.