### PR TITLE
Use the runtime-only version of Vue

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -21,7 +21,6 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.vue', '.json'],
     alias: {
-      'vue$': 'vue/dist/vue.esm.js',
       '@': resolve('src'),
       'src': path.resolve(__dirname, '../src'),
       'app': path.resolve(__dirname, '../src/app'),


### PR DESCRIPTION
The vue compiler is unnecessary when using webpack to bundle all the files at the building time. Use the runtime-only version to reduce the file size of the bundle file. [Official Doc Explanation](https://vuejs.org/v2/guide/installation.html#Runtime-Compiler-vs-Runtime-only) Here.