### PR TITLE
[ADD] Install babel-polyfill for browsers that don't support Promise

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -9,7 +9,7 @@ function resolve(dir) {
 
 module.exports = {
   entry: {
-    app: './src/main.js'
+    app: ['babel-polyfill', './src/main.js']
   },
   output: {
     path: config.build.assetsRoot,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-runtime": "^6.22.0",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.2.1",
     "babel-preset-stage-2": "^6.22.0",
     "babel-register": "^6.22.0",


### PR DESCRIPTION
The babel-polyfill is necessary for IE9.
[explanation of this issue](https://github.com/vuejs/vuex/issues/383)
